### PR TITLE
Centralize permissions

### DIFF
--- a/backend/src/database.service.ts
+++ b/backend/src/database.service.ts
@@ -81,7 +81,7 @@ export class DatabaseService {
     return await createOrUpdateUser(this.pool, user)
   }
 
-  @RequirePermissions(['createGroup'])
+  // Every user can create a group
   async createGroup(callerId: string, args: CreateGroupArguments) {
     return await createGroup(this.pool, callerId, args)
   }
@@ -91,7 +91,9 @@ export class DatabaseService {
     return await addUserToGroup(this.pool, callerId, args)
   }
 
-  @RequirePermissions(['accessGroup', 'createSplit'])
+  // Every user can create a split in a group they have access to
+  // TODO: specific permission for creating splits?
+  @RequirePermissions(['accessGroup'])
   async createSplit(callerId: string, args: CreateSplitArguments) {
     return await createSplit(this.pool, callerId, args)
   }

--- a/backend/src/database.service.ts
+++ b/backend/src/database.service.ts
@@ -17,6 +17,7 @@ import { setGroupAccess } from './database/groups/setGroupAccess'
 import { setGroupAdmin } from './database/groups/setGroupAdmin'
 import { setGroupHidden } from './database/groups/setGroupHidden'
 import { setGroupName } from './database/groups/setGroupName'
+import { RequirePermissions } from './database/permissionCheck'
 import { createSplit } from './database/splits/createSplit'
 import { deleteSplit } from './database/splits/deleteSplit'
 import { getSplitInfo } from './database/splits/getSplitInfo'
@@ -58,7 +59,7 @@ import {
 
 @Injectable()
 export class DatabaseService {
-  private pool: Pool
+  readonly pool: Pool
 
   constructor() {
     this.pool = new Pool({
@@ -80,66 +81,82 @@ export class DatabaseService {
     return await createOrUpdateUser(this.pool, user)
   }
 
-  async createGroup(userId: string, args: CreateGroupArguments) {
-    return await createGroup(this.pool, userId, args)
+  @RequirePermissions(['createGroup'])
+  async createGroup(callerId: string, args: CreateGroupArguments) {
+    return await createGroup(this.pool, callerId, args)
   }
 
+  @RequirePermissions(['accessGroup', 'manageGroup'])
   async addUserToGroup(callerId: string, args: AddUserToGroupArguments) {
     return await addUserToGroup(this.pool, callerId, args)
   }
 
+  @RequirePermissions(['accessGroup', 'createSplit'])
   async createSplit(callerId: string, args: CreateSplitArguments) {
     return await createSplit(this.pool, callerId, args)
   }
 
+  @RequirePermissions(['accessGroup', 'deleteSplit'])
   async deleteSplit(callerId: string, args: DeleteSplitArguments) {
     return await deleteSplit(this.pool, callerId, args)
   }
 
+  @RequirePermissions(['accessGroup', 'restoreSplit'])
   async restoreSplit(callerId: string, args: RestoreSplitArguments) {
     return await restoreSplit(this.pool, callerId, args)
   }
 
+  @RequirePermissions(['accessGroup', 'editSplit'])
   async updateSplit(callerId: string, args: UpdateSplitArguments) {
     return await updateSplit(this.pool, callerId, args)
   }
 
+  @RequirePermissions(['accessGroup', 'manageGroup'])
   async setGroupAccess(callerId: string, args: SetGroupAccessArguments) {
     return await setGroupAccess(this.pool, callerId, args)
   }
 
+  @RequirePermissions(['accessGroup', 'manageGroup'])
   async setGroupAdmin(callerId: string, args: SetGroupAdminArguments) {
     return await setGroupAdmin(this.pool, callerId, args)
   }
 
+  // Every user can set their own group hidden status
   async setGroupHidden(callerId: string, args: SetGroupHiddenArguments) {
     return await setGroupHidden(this.pool, callerId, args)
   }
 
+  @RequirePermissions(['accessGroup'])
   async getGroupSplits(callerId: string, args: GetGroupSplitsArguments) {
     return await getGroupSplits(this.pool, callerId, args)
   }
 
+  // Every user can see their own groups
   async getUserGroups(callerId: string, args: GetUserGroupsArguments) {
     return await getUserGroups(this.pool, callerId, args)
   }
 
+  @RequirePermissions(['accessGroup'])
   async getGroupMembers(callerId: string, args: GetGroupMembersArguments) {
     return await getGroupMembers(this.pool, callerId, args)
   }
 
+  // If email is known, every user can get user info
   async getUserByEmail(callerId: string, args: GetUserByEmailArguments) {
     return await getUserByEmail(this.pool, callerId, args)
   }
 
+  // If id is known, every user can get user info
   async getUserById(callerId: string, args: GetUserByIdArguments) {
     return await getUserById(this.pool, callerId, args)
   }
 
+  @RequirePermissions(['getGroupInfo'])
   async getGroupInfo(callerId: string, args: GetGroupInfoArguments) {
     return await getGroupInfo(this.pool, callerId, args)
   }
 
+  @RequirePermissions(['accessGroup'])
   async getGroupMembersAutocompletions(
     callerId: string,
     args: GetGroupMembersAutocompletionsArguments
@@ -147,38 +164,48 @@ export class DatabaseService {
     return await getGroupMembersAutocompletions(this.pool, callerId, args)
   }
 
+  // TODO: allow to see split if user has no access but is a participant?
+  @RequirePermissions(['accessGroup'])
   async getSplitInfo(callerId: string, args: GetSplitInfoArguments) {
     return await getSplitInfo(this.pool, callerId, args)
   }
 
+  @RequirePermissions(['accessGroup'])
   async getBalances(callerId: string, args: GetBalancesArguments) {
     return await getBalances(this.pool, callerId, args)
   }
 
+  @RequirePermissions(['accessGroup', 'deleteGroup'])
   async deleteGroup(callerId: string, args: DeleteGroupArguments) {
     return await deleteGroup(this.pool, callerId, args)
   }
 
+  @RequirePermissions(['accessGroup', 'manageGroup'])
   async setGroupName(callerId: string, args: SetGroupNameArguments) {
     return await setGroupName(this.pool, callerId, args)
   }
 
+  // Every user can join a group by link if they have it
   async joinGroupByLink(callerId: string, args: JoinGroupByLinkArguments) {
     return await joinGroupByLink(this.pool, callerId, args)
   }
 
+  // Every user can get group metadata by link if they have it
   async getGroupMetadataByLink(args: GetGroupMetadataByLinkArguments) {
     return await getGroupMetadataByLink(this.pool, args)
   }
 
+  @RequirePermissions(['accessGroup', 'manageGroup'])
   async createGroupJoinLink(callerId: string, args: CreateGroupJoinLinkArguments) {
     return await createGroupJoinLink(this.pool, callerId, args)
   }
 
+  @RequirePermissions(['accessGroup', 'manageGroup'])
   async deleteGroupJoinLink(callerId: string, args: DeleteGroupJoinLinkArguments) {
     return await deleteGroupJoinLink(this.pool, callerId, args)
   }
 
+  @RequirePermissions(['accessGroup', 'manageGroup'])
   async getGroupJoinLink(callerId: string, args: GetGroupJoinLinkArguments) {
     return await getGroupJoinLink(this.pool, callerId, args)
   }

--- a/backend/src/database/groups/addUserToGroup.ts
+++ b/backend/src/database/groups/addUserToGroup.ts
@@ -1,8 +1,6 @@
 import { ConflictException } from '../../errors/ConflictException'
-import { ForbiddenException } from '../../errors/ForbiddenException'
 import { NotFoundException } from '../../errors/NotFoundException'
 import { isGroupDeleted } from '../utils/isGroupDeleted'
-import { isUserGroupAdmin } from '../utils/isUserGroupAdmin'
 import { isUserMemberOfGroup } from '../utils/isUserMemberOfGroup'
 import { userExists } from '../utils/userExists'
 import { Pool } from 'pg'
@@ -16,10 +14,6 @@ export async function addUserToGroup(pool: Pool, callerId: string, args: AddUser
 
     if (await isGroupDeleted(client, args.groupId)) {
       throw new NotFoundException('api.notFound.group')
-    }
-
-    if (!(await isUserGroupAdmin(client, args.groupId, callerId))) {
-      throw new ForbiddenException('api.insufficientPermissions.group.addUser')
     }
 
     if (!(await userExists(client, args.userId))) {

--- a/backend/src/database/groups/createGroupJoinLink.ts
+++ b/backend/src/database/groups/createGroupJoinLink.ts
@@ -1,6 +1,4 @@
 import { BadRequestException } from '../../errors/BadRequestException'
-import { ForbiddenException } from '../../errors/ForbiddenException'
-import { isUserGroupAdmin } from '../utils/isUserGroupAdmin'
 import { Pool } from 'pg'
 import { CreateGroupJoinLinkArguments } from 'shared/src/endpointArguments'
 import { GroupJoinLink } from 'shared/src/types'
@@ -15,10 +13,6 @@ export async function createGroupJoinLink(
 
   try {
     await client.query('BEGIN')
-
-    if (!(await isUserGroupAdmin(client, args.groupId, callerId))) {
-      throw new ForbiddenException('api.insufficientPermissions.group.joinLink.create')
-    }
 
     const linkExists =
       (await client.query('SELECT 1 FROM group_join_links WHERE group_id = $1', [args.groupId]))

--- a/backend/src/database/groups/deleteGroup.ts
+++ b/backend/src/database/groups/deleteGroup.ts
@@ -1,7 +1,5 @@
-import { ForbiddenException } from '../../errors/ForbiddenException'
 import { NotFoundException } from '../../errors/NotFoundException'
 import { isGroupDeleted } from '../utils/isGroupDeleted'
-import { isUserGroupOwner } from '../utils/isUserGroupOwner'
 import { Pool } from 'pg'
 import { DeleteGroupArguments } from 'shared'
 
@@ -12,10 +10,6 @@ export async function deleteGroup(pool: Pool, callerId: string, args: DeleteGrou
 
     if (await isGroupDeleted(client, args.groupId)) {
       throw new NotFoundException('api.notFound.group')
-    }
-
-    if (!(await isUserGroupOwner(client, args.groupId, callerId))) {
-      throw new ForbiddenException('api.insufficientPermissions.group.delete')
     }
 
     await client.query('UPDATE groups SET deleted = TRUE WHERE id = $1', [args.groupId])

--- a/backend/src/database/groups/deleteGroupJoinLink.ts
+++ b/backend/src/database/groups/deleteGroupJoinLink.ts
@@ -1,6 +1,4 @@
-import { ForbiddenException } from '../../errors/ForbiddenException'
 import { NotFoundException } from '../../errors/NotFoundException'
-import { isUserGroupAdmin } from '../utils/isUserGroupAdmin'
 import { Pool } from 'pg'
 import { DeleteGroupJoinLinkArguments } from 'shared/src/endpointArguments'
 
@@ -13,10 +11,6 @@ export async function deleteGroupJoinLink(
 
   try {
     await client.query('BEGIN')
-
-    if (!(await isUserGroupAdmin(client, args.groupId, callerId))) {
-      throw new ForbiddenException('api.insufficientPermissions.group.joinLink.delete')
-    }
 
     const linkExists =
       (await client.query('SELECT 1 FROM group_join_links WHERE group_id = $1', [args.groupId]))

--- a/backend/src/database/groups/getBalances.ts
+++ b/backend/src/database/groups/getBalances.ts
@@ -1,4 +1,3 @@
-import { hasAccessToGroup } from '../utils/hasAccessToGroup'
 import { isGroupDeleted } from '../utils/isGroupDeleted'
 import { Pool } from 'pg'
 import {
@@ -8,7 +7,6 @@ import {
   isGetBalancesWithIdsArguments,
 } from 'shared'
 import { BadRequestException } from 'src/errors/BadRequestException'
-import { ForbiddenException } from 'src/errors/ForbiddenException'
 import { NotFoundException } from 'src/errors/NotFoundException'
 
 export async function getBalances(
@@ -18,10 +16,6 @@ export async function getBalances(
 ): Promise<UserWithBalanceChange[]> {
   if (await isGroupDeleted(pool, args.groupId)) {
     throw new NotFoundException('api.notFound.group')
-  }
-
-  if (!(await hasAccessToGroup(pool, args.groupId, callerId))) {
-    throw new ForbiddenException('api.insufficientPermissions.group.access')
   }
 
   let balances: Record<string, string>[] | null = null

--- a/backend/src/database/groups/getGroupInfo.ts
+++ b/backend/src/database/groups/getGroupInfo.ts
@@ -1,7 +1,5 @@
-import { ForbiddenException } from '../../errors/ForbiddenException'
 import { NotFoundException } from '../../errors/NotFoundException'
 import { isGroupDeleted } from '../utils/isGroupDeleted'
-import { isUserMemberOfGroup } from '../utils/isUserMemberOfGroup'
 import { Pool } from 'pg'
 import { GetGroupInfoArguments, GroupInfo } from 'shared'
 
@@ -12,10 +10,6 @@ export async function getGroupInfo(
 ): Promise<GroupInfo | null> {
   if (await isGroupDeleted(pool, args.groupId)) {
     throw new NotFoundException('api.notFound.group')
-  }
-
-  if (!(await isUserMemberOfGroup(pool, args.groupId, callerId))) {
-    throw new ForbiddenException('api.group.userNotInGroup')
   }
 
   const row = (

--- a/backend/src/database/groups/getGroupJoinLink.ts
+++ b/backend/src/database/groups/getGroupJoinLink.ts
@@ -1,6 +1,4 @@
-import { ForbiddenException } from '../../errors/ForbiddenException'
 import { NotFoundException } from '../../errors/NotFoundException'
-import { isUserGroupAdmin } from '../utils/isUserGroupAdmin'
 import { Pool } from 'pg'
 import { GetGroupJoinLinkArguments } from 'shared/src/endpointArguments'
 import { GroupJoinLink } from 'shared/src/types'
@@ -10,10 +8,6 @@ export async function getGroupJoinLink(
   callerId: string,
   args: GetGroupJoinLinkArguments
 ): Promise<GroupJoinLink> {
-  if (!(await isUserGroupAdmin(pool, args.groupId, callerId))) {
-    throw new ForbiddenException('api.insufficientPermissions.group.joinLink.create')
-  }
-
   const { rows } = await pool.query(
     'SELECT uuid, group_id, created_by, created_at FROM group_join_links WHERE group_id = $1',
     [args.groupId]

--- a/backend/src/database/groups/getGroupMembers.ts
+++ b/backend/src/database/groups/getGroupMembers.ts
@@ -1,6 +1,4 @@
-import { ForbiddenException } from '../../errors/ForbiddenException'
 import { NotFoundException } from '../../errors/NotFoundException'
-import { hasAccessToGroup } from '../utils/hasAccessToGroup'
 import { isGroupDeleted } from '../utils/isGroupDeleted'
 import { Pool } from 'pg'
 import { GetGroupMembersArguments, Member } from 'shared'
@@ -12,10 +10,6 @@ export async function getGroupMembers(
 ): Promise<Member[]> {
   if (await isGroupDeleted(pool, args.groupId)) {
     throw new NotFoundException('api.notFound.group')
-  }
-
-  if (!(await hasAccessToGroup(pool, args.groupId, callerId))) {
-    throw new ForbiddenException('api.insufficientPermissions.group.access')
   }
 
   const rows = (

--- a/backend/src/database/groups/getGroupMembersAutocompletions.ts
+++ b/backend/src/database/groups/getGroupMembersAutocompletions.ts
@@ -1,6 +1,4 @@
-import { ForbiddenException } from '../../errors/ForbiddenException'
 import { NotFoundException } from '../../errors/NotFoundException'
-import { hasAccessToGroup } from '../utils/hasAccessToGroup'
 import { isGroupDeleted } from '../utils/isGroupDeleted'
 import { Pool } from 'pg'
 import { GetGroupMembersAutocompletionsArguments, User } from 'shared'
@@ -12,10 +10,6 @@ export async function getGroupMembersAutocompletions(
 ): Promise<User[]> {
   if (await isGroupDeleted(pool, args.groupId)) {
     throw new NotFoundException('api.notFound.group')
-  }
-
-  if (!(await hasAccessToGroup(pool, args.groupId, callerId))) {
-    throw new ForbiddenException('api.insufficientPermissions.group.access')
   }
 
   const rows = (

--- a/backend/src/database/groups/getGroupSplits.ts
+++ b/backend/src/database/groups/getGroupSplits.ts
@@ -1,6 +1,4 @@
-import { ForbiddenException } from '../../errors/ForbiddenException'
 import { NotFoundException } from '../../errors/NotFoundException'
-import { hasAccessToGroup } from '../utils/hasAccessToGroup'
 import { isGroupDeleted } from '../utils/isGroupDeleted'
 import { Pool } from 'pg'
 import { GetGroupSplitsArguments, SplitInfo } from 'shared'
@@ -12,10 +10,6 @@ export async function getGroupSplits(
 ): Promise<SplitInfo[]> {
   if (await isGroupDeleted(pool, args.groupId)) {
     throw new NotFoundException('api.notFound.group')
-  }
-
-  if (!(await hasAccessToGroup(pool, args.groupId, callerId))) {
-    throw new ForbiddenException('api.insufficientPermissions.group.access')
   }
 
   const rows = (

--- a/backend/src/database/groups/setGroupAccess.ts
+++ b/backend/src/database/groups/setGroupAccess.ts
@@ -1,7 +1,5 @@
-import { ForbiddenException } from '../../errors/ForbiddenException'
 import { NotFoundException } from '../../errors/NotFoundException'
 import { isGroupDeleted } from '../utils/isGroupDeleted'
-import { isUserGroupAdmin } from '../utils/isUserGroupAdmin'
 import { userExists } from '../utils/userExists'
 import { Pool } from 'pg'
 import { SetGroupAccessArguments } from 'shared'
@@ -13,10 +11,6 @@ export async function setGroupAccess(pool: Pool, callerId: string, args: SetGrou
 
     if (await isGroupDeleted(client, args.groupId)) {
       throw new NotFoundException('api.notFound.group')
-    }
-
-    if (!(await isUserGroupAdmin(client, args.groupId, callerId))) {
-      throw new ForbiddenException('api.insufficientPermissions.group.setAccess')
     }
 
     if (!(await userExists(client, args.userId))) {

--- a/backend/src/database/groups/setGroupAdmin.ts
+++ b/backend/src/database/groups/setGroupAdmin.ts
@@ -1,10 +1,8 @@
 import { isGroupDeleted } from '../utils/isGroupDeleted'
-import { isUserGroupAdmin } from '../utils/isUserGroupAdmin'
 import { userExists } from '../utils/userExists'
 import { NotFoundException } from '@nestjs/common/exceptions/not-found.exception'
 import { Pool } from 'pg'
 import { SetGroupAdminArguments } from 'shared'
-import { ForbiddenException } from 'src/errors/ForbiddenException'
 
 export async function setGroupAdmin(pool: Pool, callerId: string, args: SetGroupAdminArguments) {
   const client = await pool.connect()
@@ -16,13 +14,11 @@ export async function setGroupAdmin(pool: Pool, callerId: string, args: SetGroup
       throw new NotFoundException('api.notFound.group')
     }
 
-    if (!(await isUserGroupAdmin(client, args.groupId, callerId))) {
-      throw new ForbiddenException('api.insufficientPermissions.group.setAdmin')
-    }
-
     if (!(await userExists(client, args.userId))) {
       throw new NotFoundException('notFound.user')
     }
+
+    // TODO: check if user has access to group?
 
     await client.query(
       'UPDATE group_members SET is_admin = $1 WHERE group_id = $2 AND user_id = $3',

--- a/backend/src/database/groups/setGroupName.ts
+++ b/backend/src/database/groups/setGroupName.ts
@@ -1,7 +1,5 @@
-import { ForbiddenException } from '../../errors/ForbiddenException'
 import { NotFoundException } from '../../errors/NotFoundException'
 import { isGroupDeleted } from '../utils/isGroupDeleted'
-import { isUserGroupAdmin } from '../utils/isUserGroupAdmin'
 import { Pool } from 'pg'
 import { SetGroupNameArguments } from 'shared'
 
@@ -13,10 +11,6 @@ export async function setGroupName(pool: Pool, callerId: string, args: SetGroupN
 
     if (await isGroupDeleted(client, args.groupId)) {
       throw new NotFoundException('api.notFound.group')
-    }
-
-    if (!(await isUserGroupAdmin(client, args.groupId, callerId))) {
-      throw new ForbiddenException('api.insufficientPermissions.group.setName')
     }
 
     await client.query('UPDATE groups SET name = $1 WHERE id = $2', [args.name, args.groupId])

--- a/backend/src/database/permissionCheck/checkPermissions.ts
+++ b/backend/src/database/permissionCheck/checkPermissions.ts
@@ -16,10 +16,6 @@ export async function checkPermissions<TPermissions extends (keyof PermissionToF
     const args = unsafeArgs as PermissionArguments<[typeof permission]>
 
     switch (permission) {
-      case 'createGroup':
-        // every user can create a group
-        return null
-
       case 'accessGroup':
         if (!(await hasAccessToGroup(pool, args.groupId, callerId))) {
           return 'api.insufficientPermissions.group.access'
@@ -29,13 +25,6 @@ export async function checkPermissions<TPermissions extends (keyof PermissionToF
       case 'manageGroup':
         if (!(await isUserGroupAdmin(pool, args.groupId, callerId))) {
           return 'api.insufficientPermissions.group.manage'
-        }
-        return null
-
-      case 'createSplit':
-        // TODO: specific permission for creating splits?
-        if (!(await hasAccessToGroup(pool, args.groupId, callerId))) {
-          return 'api.insufficientPermissions.group.createSplit'
         }
         return null
 
@@ -53,12 +42,7 @@ export async function checkPermissions<TPermissions extends (keyof PermissionToF
           )
         ).rows[0]
 
-        if (
-          splitInfo &&
-          splitInfo.created_by !== callerId &&
-          splitInfo.paid_by !== callerId &&
-          !(await isUserGroupAdmin(pool, args.groupId, callerId))
-        ) {
+        if (splitInfo && splitInfo.created_by !== callerId && splitInfo.paid_by !== callerId) {
           return `api.insufficientPermissions.group.${permission}`
         }
 

--- a/backend/src/database/permissionCheck/checkPermissions.ts
+++ b/backend/src/database/permissionCheck/checkPermissions.ts
@@ -1,0 +1,84 @@
+import { hasAccessToGroup } from '../utils/hasAccessToGroup'
+import { isUserGroupAdmin } from '../utils/isUserGroupAdmin'
+import { isUserGroupOwner } from '../utils/isUserGroupOwner'
+import { isUserMemberOfGroup } from '../utils/isUserMemberOfGroup'
+import { PermissionArguments, PermissionToFieldMap } from './permissions'
+import { Pool } from 'pg'
+import { LanguageTranslationKey } from 'shared'
+
+export async function checkPermissions<TPermissions extends (keyof PermissionToFieldMap)[]>(
+  pool: Pool,
+  callerId: string,
+  permissions: TPermissions,
+  unsafeArgs: PermissionArguments<TPermissions>
+): Promise<LanguageTranslationKey | null> {
+  for (const permission of permissions) {
+    const args = unsafeArgs as PermissionArguments<[typeof permission]>
+
+    switch (permission) {
+      case 'createGroup':
+        // every user can create a group
+        return null
+
+      case 'accessGroup':
+        if (!(await hasAccessToGroup(pool, args.groupId, callerId))) {
+          return 'api.insufficientPermissions.group.access'
+        }
+        return null
+
+      case 'manageGroup':
+        if (!(await isUserGroupAdmin(pool, args.groupId, callerId))) {
+          return 'api.insufficientPermissions.group.manage'
+        }
+        return null
+
+      case 'createSplit':
+        // TODO: specific permission for creating splits?
+        if (!(await hasAccessToGroup(pool, args.groupId, callerId))) {
+          return 'api.insufficientPermissions.group.createSplit'
+        }
+        return null
+
+      case 'deleteSplit':
+      case 'restoreSplit':
+      case 'editSplit':
+        if (await isUserGroupAdmin(pool, args.groupId, callerId)) {
+          return null
+        }
+
+        const splitInfo = (
+          await pool.query<{ paid_by: string; created_by: string; total: string }>(
+            'SELECT paid_by, created_by, total FROM splits WHERE group_id = $1 AND id = $2',
+            [args.groupId, args.splitId]
+          )
+        ).rows[0]
+
+        if (
+          splitInfo &&
+          splitInfo.created_by !== callerId &&
+          splitInfo.paid_by !== callerId &&
+          !(await isUserGroupAdmin(pool, args.groupId, callerId))
+        ) {
+          return `api.insufficientPermissions.group.${permission}`
+        }
+
+        return null
+
+      case 'getGroupInfo':
+        if (!(await isUserMemberOfGroup(pool, args.groupId, callerId))) {
+          return 'api.group.userNotInGroup'
+        }
+        return null
+
+      case 'deleteGroup':
+        if (!(await isUserGroupOwner(pool, args.groupId, callerId))) {
+          return 'api.insufficientPermissions.group.delete'
+        }
+        return null
+
+      default:
+        console.log('Unknown permission required:', permission)
+        return 'unknownError'
+    }
+  }
+}

--- a/backend/src/database/permissionCheck/index.ts
+++ b/backend/src/database/permissionCheck/index.ts
@@ -1,0 +1,2 @@
+export { RequirePermissions } from './requirePermissions'
+export { PermissionToFieldMap, PermissionArguments } from './permissions'

--- a/backend/src/database/permissionCheck/permissions.ts
+++ b/backend/src/database/permissionCheck/permissions.ts
@@ -1,0 +1,19 @@
+export const PermissionToFieldMap = {
+  createGroup: [] as const,
+  accessGroup: ['groupId'] as const,
+  getGroupInfo: ['groupId'] as const,
+  manageGroup: ['groupId'] as const,
+  deleteGroup: ['groupId'] as const,
+  createSplit: ['groupId'] as const,
+  deleteSplit: ['groupId', 'splitId'] as const,
+  restoreSplit: ['groupId', 'splitId'] as const,
+  editSplit: ['groupId', 'splitId'] as const,
+}
+
+export type PermissionToFieldMap = typeof PermissionToFieldMap
+
+type ObjectFromArray<T extends (keyof PermissionToFieldMap)[]> = {
+  [K in T[number] as PermissionToFieldMap[K][number]]: Exclude<any, undefined | null>
+}
+
+export type PermissionArguments<T extends (keyof PermissionToFieldMap)[]> = ObjectFromArray<T>

--- a/backend/src/database/permissionCheck/permissions.ts
+++ b/backend/src/database/permissionCheck/permissions.ts
@@ -1,10 +1,8 @@
 export const PermissionToFieldMap = {
-  createGroup: [] as const,
   accessGroup: ['groupId'] as const,
   getGroupInfo: ['groupId'] as const,
   manageGroup: ['groupId'] as const,
   deleteGroup: ['groupId'] as const,
-  createSplit: ['groupId'] as const,
   deleteSplit: ['groupId', 'splitId'] as const,
   restoreSplit: ['groupId', 'splitId'] as const,
   editSplit: ['groupId', 'splitId'] as const,

--- a/backend/src/database/permissionCheck/requirePermissions.ts
+++ b/backend/src/database/permissionCheck/requirePermissions.ts
@@ -1,0 +1,58 @@
+import { ForbiddenException } from '../../errors/ForbiddenException'
+import { checkPermissions } from './checkPermissions'
+import { PermissionArguments, PermissionToFieldMap } from './permissions'
+import { Pool } from 'pg'
+
+interface HasDatabasePool {
+  pool: Pool
+}
+
+function validateArguments<TPermissions extends (keyof PermissionToFieldMap)[]>(
+  permissions: TPermissions,
+  args: PermissionArguments<TPermissions>
+) {
+  for (const permission of permissions) {
+    const fields = PermissionToFieldMap[permission]
+
+    for (const field of fields) {
+      if (!args[field]) {
+        throw new Error(`Missing required field: ${field}`)
+      }
+    }
+  }
+}
+
+export function RequirePermissions<
+  TTarget extends HasDatabasePool,
+  TPermissions extends (keyof PermissionToFieldMap)[],
+>(permissions: TPermissions) {
+  return function <TArgs extends PermissionArguments<TPermissions>>(
+    target: TTarget,
+    propertyKey: string | symbol,
+    descriptor: TypedPropertyDescriptor<(callerId: string, args: TArgs, ...rest: any[]) => any>
+  ) {
+    const originalMethod = descriptor.value
+
+    descriptor.value = async function (
+      this: TTarget,
+      callerId: string,
+      args: TArgs,
+      ...rest: any[]
+    ) {
+      validateArguments(permissions, args)
+      if (!this.pool) {
+        throw new Error('Database pool is not initialized')
+      }
+
+      const error = await checkPermissions(this.pool, callerId, permissions, args)
+
+      if (error !== null) {
+        throw new ForbiddenException(error)
+      }
+
+      return originalMethod.apply(this, [callerId, args, ...rest])
+    }
+
+    return descriptor
+  }
+}

--- a/backend/src/database/splits/createSplit.ts
+++ b/backend/src/database/splits/createSplit.ts
@@ -1,6 +1,4 @@
-import { ForbiddenException } from '../../errors/ForbiddenException'
 import { NotFoundException } from '../../errors/NotFoundException'
-import { hasAccessToGroup } from '../utils/hasAccessToGroup'
 import { isGroupDeleted } from '../utils/isGroupDeleted'
 import { userExists } from '../utils/userExists'
 import { Pool } from 'pg'
@@ -14,10 +12,6 @@ export async function createSplit(pool: Pool, callerId: string, args: CreateSpli
 
     if (await isGroupDeleted(client, args.groupId)) {
       throw new NotFoundException('api.notFound.group')
-    }
-
-    if (!(await hasAccessToGroup(client, args.groupId, callerId))) {
-      throw new ForbiddenException('api.insufficientPermissions.group.createSplit')
     }
 
     const splitId = (

--- a/backend/src/database/splits/getSplitInfo.ts
+++ b/backend/src/database/splits/getSplitInfo.ts
@@ -1,6 +1,4 @@
-import { ForbiddenException } from '../../errors/ForbiddenException'
 import { NotFoundException } from '../../errors/NotFoundException'
-import { hasAccessToGroup } from '../utils/hasAccessToGroup'
 import { isGroupDeleted } from '../utils/isGroupDeleted'
 import { Pool } from 'pg'
 import { GetSplitInfoArguments, SplitWithUsers } from 'shared'
@@ -12,11 +10,6 @@ export async function getSplitInfo(
 ): Promise<SplitWithUsers> {
   if (await isGroupDeleted(pool, args.groupId)) {
     throw new NotFoundException('api.notFound.group')
-  }
-
-  // TODO: allow to see split if user has no access but is a participant?
-  if (!(await hasAccessToGroup(pool, args.groupId, callerId))) {
-    throw new ForbiddenException('api.insufficientPermissions.group.access')
   }
 
   const splitRow = (

--- a/backend/src/database/splits/restoreSplit.ts
+++ b/backend/src/database/splits/restoreSplit.ts
@@ -1,8 +1,5 @@
-import { ForbiddenException } from '../../errors/ForbiddenException'
 import { NotFoundException } from '../../errors/NotFoundException'
-import { hasAccessToGroup } from '../utils/hasAccessToGroup'
 import { isGroupDeleted } from '../utils/isGroupDeleted'
-import { isUserGroupAdmin } from '../utils/isUserGroupAdmin'
 import { splitExists } from '../utils/splitExists'
 import { Pool } from 'pg'
 import { RestoreSplitArguments } from 'shared'
@@ -16,10 +13,6 @@ export async function restoreSplit(pool: Pool, callerId: string, args: RestoreSp
       throw new NotFoundException('api.notFound.group')
     }
 
-    if (!(await hasAccessToGroup(client, args.groupId, callerId))) {
-      throw new ForbiddenException('api.insufficientPermissions.group.access')
-    }
-
     if (!(await splitExists(client, args.groupId, args.splitId))) {
       throw new NotFoundException('api.notFound.split')
     }
@@ -30,14 +23,6 @@ export async function restoreSplit(pool: Pool, callerId: string, args: RestoreSp
         [args.groupId, args.splitId]
       )
     ).rows[0]
-
-    if (
-      splitInfo.created_by !== callerId &&
-      splitInfo.paid_by !== callerId &&
-      !(await isUserGroupAdmin(client, args.groupId, callerId))
-    ) {
-      throw new ForbiddenException('api.insufficientPermissions.group.restoreSplit')
-    }
 
     const splitParticipants = (
       await client.query('SELECT user_id, change FROM split_participants WHERE split_id = $1', [

--- a/backend/src/database/splits/updateSplit.ts
+++ b/backend/src/database/splits/updateSplit.ts
@@ -1,8 +1,5 @@
-import { ForbiddenException } from '../../errors/ForbiddenException'
 import { NotFoundException } from '../../errors/NotFoundException'
-import { hasAccessToGroup } from '../utils/hasAccessToGroup'
 import { isGroupDeleted } from '../utils/isGroupDeleted'
-import { isUserGroupAdmin } from '../utils/isUserGroupAdmin'
 import { splitExists } from '../utils/splitExists'
 import { Pool } from 'pg'
 import { UpdateSplitArguments } from 'shared'
@@ -14,10 +11,6 @@ export async function updateSplit(pool: Pool, callerId: string, args: UpdateSpli
 
     if (await isGroupDeleted(client, args.groupId)) {
       throw new NotFoundException('api.notFound.group')
-    }
-
-    if (!(await hasAccessToGroup(client, args.groupId, callerId))) {
-      throw new ForbiddenException('api.insufficientPermissions.group.access')
     }
 
     if (!(await splitExists(client, args.groupId, args.splitId))) {
@@ -40,14 +33,6 @@ export async function updateSplit(pool: Pool, callerId: string, args: UpdateSpli
         [args.groupId, args.splitId]
       )
     ).rows[0]
-
-    if (
-      splitInfo.created_by !== callerId &&
-      splitInfo.paid_by !== callerId &&
-      !(await isUserGroupAdmin(client, args.groupId, callerId))
-    ) {
-      throw new ForbiddenException('api.insufficientPermissions.group.editSplit')
-    }
 
     // Remove old balances
 

--- a/frontend/components/TextInputWithSuggestions.tsx
+++ b/frontend/components/TextInputWithSuggestions.tsx
@@ -33,7 +33,11 @@ export function TextInputWithSuggestions<T>({
 
   useEffect(() => {
     if (isFocusedDebounced && debouncedValue && debouncedValue.length > 0) {
-      getSuggestions(debouncedValue).then(setSuggestions)
+      getSuggestions(debouncedValue)
+        .then(setSuggestions)
+        .catch((error) => {
+          console.error('Error getting suggestions', error)
+        })
     } else {
       setSuggestions([])
     }

--- a/shared/src/locales/en/translation.json
+++ b/shared/src/locales/en/translation.json
@@ -25,11 +25,8 @@
     "insufficientPermissions": {
       "group": {
         "access": "User does not have access to group",
-        "addUser": "User does not have permission to add users to the group",
-        "setAdmin": "User does not have permission to manage group admins",
-        "setAccess": "User does not have permission to manage group access",
+        "manage": "User does not have permission to manage the group",
         "delete": "User does not have permission to delete the group",
-        "setName": "User does not have permission to change the group name",
         "createSplit": "User does not have permission to create splits in the group",
         "deleteSplit": "User does not have permission to delete this split",
         "editSplit": "User does not have permission to edit this split",


### PR DESCRIPTION
Moves permission checks from being implemented in every endpoint separately to being centralized in one place and managed by a decorator.