### PR TITLE
Implement one-on-one settle up

### DIFF
--- a/backend/src/app.controller.ts
+++ b/backend/src/app.controller.ts
@@ -585,7 +585,7 @@ export class AppController {
   async getSettleUpPreview(@Req() request: Request, @Query() query: Record<string, string>) {
     const args: SettleUpArguments = {
       groupId: parseInt(query.groupId),
-      withMembers: query.withMembers?.split(','),
+      withMembers: query.withMembers?.split?.(','),
     }
 
     // TODO: add support for full subgroup settle up (only one on one settle up for now)
@@ -598,13 +598,7 @@ export class AppController {
 
   @UseGuards(AuthGuard)
   @Post('confirmSettleUp')
-  async confirmSettleUp(@Req() request: Request, @Body() query: Record<string, string>) {
-    const args: ConfirmSettleUpArguments = {
-      groupId: parseInt(query.groupId),
-      entriesHash: query.entriesHash,
-      withMembers: query.withMembers?.split(','),
-    }
-
+  async confirmSettleUp(@Req() request: Request, @Body() args: Partial<ConfirmSettleUpArguments>) {
     // TODO: add support for full subgroup settle up (only one on one settle up for now)
     if (!isConfirmSettleUpArguments(args) || (args.withMembers?.length ?? 0) > 1) {
       throw new BadRequestException('api.invalidArguments')

--- a/backend/src/app.controller.ts
+++ b/backend/src/app.controller.ts
@@ -582,8 +582,14 @@ export class AppController {
 
   @UseGuards(AuthGuard)
   @Get('getSettleUpPreview')
-  async getSettleUpPreview(@Req() request: Request, @Query() args: Partial<SettleUpArguments>) {
-    if (!isSettleUpArguments(args)) {
+  async getSettleUpPreview(@Req() request: Request, @Query() query: Record<string, string>) {
+    const args: SettleUpArguments = {
+      groupId: parseInt(query.groupId),
+      withMembers: query.withMembers?.split(','),
+    }
+
+    // TODO: add support for full subgroup settle up (only one on one settle up for now)
+    if (!isSettleUpArguments(args) || (args.withMembers?.length ?? 0) > 1) {
       throw new BadRequestException('api.invalidArguments')
     }
 
@@ -592,8 +598,15 @@ export class AppController {
 
   @UseGuards(AuthGuard)
   @Post('confirmSettleUp')
-  async confirmSettleUp(@Req() request: Request, @Body() args: Partial<ConfirmSettleUpArguments>) {
-    if (!isConfirmSettleUpArguments(args)) {
+  async confirmSettleUp(@Req() request: Request, @Body() query: Record<string, string>) {
+    const args: ConfirmSettleUpArguments = {
+      groupId: parseInt(query.groupId),
+      entriesHash: query.entriesHash,
+      withMembers: query.withMembers?.split(','),
+    }
+
+    // TODO: add support for full subgroup settle up (only one on one settle up for now)
+    if (!isConfirmSettleUpArguments(args) || (args.withMembers?.length ?? 0) > 1) {
       throw new BadRequestException('api.invalidArguments')
     }
 

--- a/backend/src/database/splits/confirmSettleUp.ts
+++ b/backend/src/database/splits/confirmSettleUp.ts
@@ -139,7 +139,8 @@ export async function confirmSettleUp(
       callerId,
       balance,
       settleUpData.members,
-      settleUpData.pendingChanges
+      settleUpData.pendingChanges,
+      args.withMembers
     )
     const entriesHash = hash(entries, { algorithm: 'sha1', encoding: 'base64' })
 

--- a/backend/src/database/splits/getSettleUpPreview.ts
+++ b/backend/src/database/splits/getSettleUpPreview.ts
@@ -42,7 +42,8 @@ export async function getSettleUpPreview(
       callerId,
       balance,
       settleUpData.members,
-      settleUpData.pendingChanges
+      settleUpData.pendingChanges,
+      args.withMembers
     )
 
     if (entries.length === 1) {

--- a/backend/src/database/utils/prepareSettleUp.ts
+++ b/backend/src/database/utils/prepareSettleUp.ts
@@ -68,9 +68,11 @@ export function prepareSettleUp(
   payerId: string,
   balance: number,
   allMembers: Member[],
-  pendingChanges: TargetedBalanceChange[]
+  pendingChanges: TargetedBalanceChange[],
+  withMembers?: string[]
 ): BalanceChange[] {
   // TODO: Better algorithm for this
+  const entries: BalanceChange[] = [{ id: payerId, change: '0.00', pending: false }]
 
   pendingChanges.forEach((change) => {
     const member = allMembers.find((m) => m.id === change.id)
@@ -88,6 +90,17 @@ export function prepareSettleUp(
       }
     }
   })
+
+  if (withMembers !== undefined) {
+    // TODO: add support for full subgroup settle up (only one on one settle up for now)
+    assert(withMembers.length === 1)
+
+    const member = allMembers.find((m) => m.id === withMembers[0])
+    assert(member !== undefined)
+
+    entries.push({ id: member.id, change: balance.toFixed(2), pending: true })
+    return entries
+  }
 
   // This should result in a list of members with the opposite sign of the balance
   // grouped by whether they have access or not and sorted by balance descending.
@@ -118,7 +131,6 @@ export function prepareSettleUp(
     })
 
   let workingBalance = balance
-  const entries: BalanceChange[] = [{ id: payerId, change: '0.00', pending: false }]
 
   for (const member of members) {
     const memberBalance = Number(member.balance)

--- a/backend/src/database/utils/prepareSettleUp.ts
+++ b/backend/src/database/utils/prepareSettleUp.ts
@@ -98,7 +98,10 @@ export function prepareSettleUp(
     const member = allMembers.find((m) => m.id === withMembers[0])
     assert(member !== undefined)
 
-    entries.push({ id: member.id, change: balance.toFixed(2), pending: true })
+    if (balance !== 0) {
+      entries.push({ id: member.id, change: balance.toFixed(2), pending: true })
+    }
+
     return entries
   }
 

--- a/frontend/app/group/[id]/member/[memberId].tsx
+++ b/frontend/app/group/[id]/member/[memberId].tsx
@@ -1,9 +1,11 @@
+import { Button } from '@components/Button'
 import { EditableText } from '@components/EditableText'
 import { Icon } from '@components/Icon'
 import ModalScreen from '@components/ModalScreen'
 import { ProfilePicture } from '@components/ProfilePicture'
 import { ShimmerPlaceholder } from '@components/ShimmerPlaceholder'
 import { Text } from '@components/Text'
+import { useGroupInfo } from '@hooks/database/useGroupInfo'
 import { useGroupMemberInfo } from '@hooks/database/useGroupMemberInfo'
 import { useGroupPermissions } from '@hooks/database/useGroupPermissions'
 import { useSetUserDisplayNameMutation } from '@hooks/database/useSetUserDisplayName'
@@ -23,6 +25,7 @@ export function MemberScreen() {
   const insets = useModalScreenInsets()
   const { t } = useTranslation()
   const { id: groupId, memberId } = useLocalSearchParams()
+  const { data: groupInfo } = useGroupInfo(Number(groupId))
   const { data: userPermissions } = useGroupPermissions(Number(groupId))
   const { data: memberInfo, error } = useGroupMemberInfo(Number(groupId), String(memberId))
 
@@ -190,6 +193,19 @@ export function MemberScreen() {
               ) : null}
             </View>
           )}
+
+          {userPermissions?.canSettleUp() &&
+            Math.sign(Number(groupInfo?.balance) * Number(memberInfo?.balance)) === -1 && (
+              <View style={{ width: '100%' }}>
+                <Button
+                  leftIcon='balance'
+                  title={t('memberInfo.settleUpWithMember')}
+                  onPress={() => {
+                    alert('TODO')
+                  }}
+                />
+              </View>
+            )}
         </View>
       </View>
     </View>

--- a/frontend/app/group/[id]/member/[memberId].tsx
+++ b/frontend/app/group/[id]/member/[memberId].tsx
@@ -13,7 +13,7 @@ import { useModalScreenInsets } from '@hooks/useModalScreenInsets'
 import { useTheme } from '@styling/theme'
 import { useAuth } from '@utils/auth'
 import { getBalanceColor } from '@utils/getBalanceColor'
-import { useLocalSearchParams } from 'expo-router'
+import { useLocalSearchParams, useRouter } from 'expo-router'
 import React from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import { View } from 'react-native'
@@ -23,6 +23,7 @@ export function MemberScreen() {
   const user = useAuth()
   const theme = useTheme()
   const insets = useModalScreenInsets()
+  const router = useRouter()
   const { t } = useTranslation()
   const { id: groupId, memberId } = useLocalSearchParams()
   const { data: groupInfo } = useGroupInfo(Number(groupId))
@@ -195,13 +196,14 @@ export function MemberScreen() {
           )}
 
           {userPermissions?.canSettleUp() &&
-            Math.sign(Number(groupInfo?.balance) * Number(memberInfo?.balance)) === -1 && (
+            memberId !== user?.id &&
+            Number(groupInfo?.balance) !== 0 && (
               <View style={{ width: '100%' }}>
                 <Button
                   leftIcon='balance'
                   title={t('memberInfo.settleUpWithMember')}
                   onPress={() => {
-                    alert('TODO')
+                    router.navigate(`/group/${groupId}/settleUp?withMembers=${memberId}`)
                   }}
                 />
               </View>

--- a/frontend/app/group/[id]/member/[memberId].tsx
+++ b/frontend/app/group/[id]/member/[memberId].tsx
@@ -17,7 +17,7 @@ import { useLocalSearchParams, useRouter } from 'expo-router'
 import React from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import { View } from 'react-native'
-import { isTranslatableError } from 'shared'
+import { CurrencyUtils, isTranslatableError } from 'shared'
 
 export function MemberScreen() {
   const user = useAuth()
@@ -140,7 +140,9 @@ export function MemberScreen() {
             {(memberInfo) => (
               <Text style={{ fontSize: 22, fontWeight: '500', color: theme.colors.onSurface }}>
                 <Trans
-                  values={{ balance: memberInfo.balance }}
+                  values={{
+                    balance: CurrencyUtils.format(memberInfo.balance, groupInfo?.currency),
+                  }}
                   i18nKey={'memberInfo.balance'}
                   components={{
                     Styled: (

--- a/frontend/app/group/[id]/settleUp.tsx
+++ b/frontend/app/group/[id]/settleUp.tsx
@@ -17,13 +17,15 @@ interface SettleUpPreviewProps {
   preview: SplitWithHashedChanges
   groupInfo: GroupUserInfo
   goBack: () => void
+  withMembers?: string[]
 }
 
 function SettleUpPreview(props: SettleUpPreviewProps) {
   const insets = useModalScreenInsets()
   const { t } = useTranslation()
   const { mutateAsync: confirmSettleUp, isPending: isCompleting } = useConfirmSettleUpMutation(
-    props.groupInfo.id
+    props.groupInfo.id,
+    props.withMembers
   )
 
   return (
@@ -74,9 +76,18 @@ function SettleUpPreview(props: SettleUpPreviewProps) {
 
 export default function SettleUp() {
   const { t } = useTranslation()
-  const { id } = useLocalSearchParams()
+  const { id, withMembers: withMembersQuery } = useLocalSearchParams<{
+    id: string
+    withMembers?: string
+  }>()
+
+  const withMembers = withMembersQuery?.split(',')
+
   const { data: groupInfo } = useGroupInfo(Number(id))
-  const { data: settleUpPreview, error: settleUpError } = useSettleUpPreview(Number(id))
+  const { data: settleUpPreview, error: settleUpError } = useSettleUpPreview(
+    Number(id),
+    withMembers
+  )
   const router = useRouter()
   const theme = useTheme()
 
@@ -102,7 +113,12 @@ export default function SettleUp() {
   return (
     <Modal title={t('screenName.settleUp')} returnPath={`/group/${id}`} maxWidth={600}>
       {settleUpPreview && groupInfo ? (
-        <SettleUpPreview preview={settleUpPreview} groupInfo={groupInfo} goBack={goBack} />
+        <SettleUpPreview
+          preview={settleUpPreview}
+          groupInfo={groupInfo}
+          goBack={goBack}
+          withMembers={withMembers}
+        />
       ) : (
         <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
           <ActivityIndicator size='large' color={theme.colors.onSurface} />

--- a/frontend/app/group/[id]/settleUp.tsx
+++ b/frontend/app/group/[id]/settleUp.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@components/Button'
 import Modal from '@components/ModalScreen'
+import { useSnack } from '@components/SnackBar'
 import { SplitInfo } from '@components/SplitInfo'
 import { useConfirmSettleUpMutation } from '@hooks/database/useConfirmSettleUpMutation'
 import { useGroupInfo } from '@hooks/database/useGroupInfo'
@@ -22,6 +23,8 @@ interface SettleUpPreviewProps {
 
 function SettleUpPreview(props: SettleUpPreviewProps) {
   const insets = useModalScreenInsets()
+  const snack = useSnack()
+  const router = useRouter()
   const { t } = useTranslation()
   const { mutateAsync: confirmSettleUp, isPending: isCompleting } = useConfirmSettleUpMutation(
     props.groupInfo.id,
@@ -57,7 +60,14 @@ function SettleUpPreview(props: SettleUpPreviewProps) {
                 alert(t('unknownError'))
               }
             })
-            .then(() => {
+            .then((split) => {
+              snack.show({
+                message: t('groupInfo.settleUp.settleUpSuccess'),
+                actionText: t('groupInfo.settleUp.openSettleUp'),
+                action: async () => {
+                  router.navigate(`/group/${props.groupInfo.id}/split/${split!.id}`)
+                },
+              })
               props.goBack()
             })
         }}

--- a/frontend/components/SnackBar.tsx
+++ b/frontend/components/SnackBar.tsx
@@ -17,7 +17,7 @@ import Animated, {
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { isTranslatableError } from 'shared'
 
-const SNACK_DURATION_SHORT = 2500
+const SNACK_DURATION_SHORT = 3000
 const SNACK_DURATION_MEDIUM = 5000
 const SNACK_DURATION_LONG = 10000
 

--- a/frontend/hooks/database/useConfirmSettleUpMutation.ts
+++ b/frontend/hooks/database/useConfirmSettleUpMutation.ts
@@ -1,13 +1,19 @@
 import { useMutation } from '@tanstack/react-query'
 import { makeRequest } from '@utils/makeApiRequest'
 import { invalidateGroup } from '@utils/queryClient'
-import { ConfirmSettleUpArguments } from 'shared'
+import { ConfirmSettleUpArguments, SplitInfo } from 'shared'
 
 async function confirmSettleUp(groupId: number, hash: string, withMembers?: string[]) {
   const args: ConfirmSettleUpArguments = { groupId, entriesHash: hash, withMembers }
 
-  await makeRequest('POST', 'confirmSettleUp', args)
+  const split = await makeRequest<ConfirmSettleUpArguments, SplitInfo>(
+    'POST',
+    'confirmSettleUp',
+    args
+  )
   await invalidateGroup(groupId)
+
+  return split
 }
 
 export function useConfirmSettleUpMutation(groupId: number, withMembers?: string[]) {

--- a/frontend/hooks/database/useConfirmSettleUpMutation.ts
+++ b/frontend/hooks/database/useConfirmSettleUpMutation.ts
@@ -10,9 +10,8 @@ async function confirmSettleUp(groupId: number, hash: string, withMembers?: stri
   await invalidateGroup(groupId)
 }
 
-export function useConfirmSettleUpMutation(groupId: number) {
+export function useConfirmSettleUpMutation(groupId: number, withMembers?: string[]) {
   return useMutation({
-    mutationFn: (hash: string, withMembers?: string[]) =>
-      confirmSettleUp(groupId, hash, withMembers),
+    mutationFn: (hash: string) => confirmSettleUp(groupId, hash, withMembers),
   })
 }

--- a/frontend/hooks/database/useConfirmSettleUpMutation.ts
+++ b/frontend/hooks/database/useConfirmSettleUpMutation.ts
@@ -3,8 +3,8 @@ import { makeRequest } from '@utils/makeApiRequest'
 import { invalidateGroup } from '@utils/queryClient'
 import { ConfirmSettleUpArguments } from 'shared'
 
-async function confirmSettleUp(groupId: number, hash: string) {
-  const args: ConfirmSettleUpArguments = { groupId, entriesHash: hash }
+async function confirmSettleUp(groupId: number, hash: string, withMembers?: string[]) {
+  const args: ConfirmSettleUpArguments = { groupId, entriesHash: hash, withMembers }
 
   await makeRequest('POST', 'confirmSettleUp', args)
   await invalidateGroup(groupId)
@@ -12,6 +12,7 @@ async function confirmSettleUp(groupId: number, hash: string) {
 
 export function useConfirmSettleUpMutation(groupId: number) {
   return useMutation({
-    mutationFn: (hash: string) => confirmSettleUp(groupId, hash),
+    mutationFn: (hash: string, withMembers?: string[]) =>
+      confirmSettleUp(groupId, hash, withMembers),
   })
 }

--- a/frontend/hooks/database/useSettleUpPreview.ts
+++ b/frontend/hooks/database/useSettleUpPreview.ts
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/react-query'
 import { ApiError, makeRequest } from '@utils/makeApiRequest'
 import { SettleUpArguments, SplitWithHashedChanges, TranslatableError } from 'shared'
 
-export function useSettleUpPreview(groupId?: number) {
+export function useSettleUpPreview(groupId?: number, withMembers?: string[]) {
   return useQuery({
     queryKey: ['settleUpPreview', groupId, Math.random()],
     queryFn: async (): Promise<SplitWithHashedChanges | null> => {
@@ -10,7 +10,7 @@ export function useSettleUpPreview(groupId?: number) {
         return null
       }
 
-      const args: SettleUpArguments = { groupId: groupId }
+      const args: SettleUpArguments = { groupId: groupId, withMembers: withMembers }
       const info = await makeRequest<SettleUpArguments, SplitWithHashedChanges>(
         'GET',
         'getSettleUpPreview',

--- a/frontend/utils/queryClient.ts
+++ b/frontend/utils/queryClient.ts
@@ -18,6 +18,7 @@ export async function deleteGroupQueries(groupId: number) {
 }
 
 export async function invalidateGroup(groupId: number) {
+  await queryClient.invalidateQueries({ queryKey: ['group', groupId] })
   await queryClient.invalidateQueries({ queryKey: ['groupSplits', groupId] })
   await queryClient.invalidateQueries({ queryKey: ['groupMembers', groupId] })
   await queryClient.invalidateQueries({ queryKey: ['groupInfo', groupId] })

--- a/shared/src/endpointArguments.ts
+++ b/shared/src/endpointArguments.ts
@@ -178,11 +178,13 @@ export interface SetUserNameArguments {
 
 export interface SettleUpArguments {
   groupId: number
+  withMembers?: string[]
 }
 
 export interface ConfirmSettleUpArguments {
   groupId: number
   entriesHash: string
+  withMembers?: string[]
 }
 
 export interface SetUserDisplayNameArguments {

--- a/shared/src/locales/en/translation.json
+++ b/shared/src/locales/en/translation.json
@@ -203,7 +203,8 @@
     "displayNamePlaceholder": "Display name",
     "balance": "Balance: <Styled>{{balance}}</Styled>",
     "admin": "Moderator of this group",
-    "noAccess": "No access to this group"
+    "noAccess": "No access to this group",
+    "settleUpWithMember": "Settle up with this person"
   },
 
   "screenName": {

--- a/shared/src/locales/en/translation.json
+++ b/shared/src/locales/en/translation.json
@@ -378,7 +378,8 @@
       "settleUp": "Settle up",
       "confirm": "Confirm",
       "cancel": "Cancel",
-      "settleUpSuccess": "Settled up"
+      "settleUpSuccess": "Settled up",
+      "openSettleUp": "Show"
     }
   },
 


### PR DESCRIPTION
Adds an option to settle up with a selected group member on their page in the members list.

The same mechanism could be used in the future for subgroup settle-ups.