### PR TITLE
Send currency when creating and updating splits

### DIFF
--- a/backend/src/database/groups/createGroup.ts
+++ b/backend/src/database/groups/createGroup.ts
@@ -1,4 +1,5 @@
 import { addUserToGroup } from '../utils/addUserToGroup'
+import { validateCurrency } from '../utils/validateCurrency'
 import { Pool } from 'pg'
 import { CreateGroupArguments, GroupType, GroupUserInfo } from 'shared'
 
@@ -10,6 +11,8 @@ export async function createGroup(
   const client = await pool.connect()
 
   try {
+    validateCurrency(args.currency)
+
     await client.query('BEGIN')
 
     const { rows } = await client.query(

--- a/backend/src/database/splits/createSplit.ts
+++ b/backend/src/database/splits/createSplit.ts
@@ -12,6 +12,8 @@ export async function createSplitNoTransaction(
   callerId: string,
   args: CreateSplitArguments
 ): Promise<number> {
+  // TODO: validate currency
+
   const splitId = (
     await client.query(
       `

--- a/backend/src/database/splits/updateSplit.ts
+++ b/backend/src/database/splits/updateSplit.ts
@@ -134,6 +134,8 @@ async function dispatchNotifications(
 export async function updateSplit(pool: Pool, callerId: string, args: UpdateSplitArguments) {
   const client = await pool.connect()
   try {
+    // TODO: validate currency
+
     await client.query('BEGIN')
 
     if (await isGroupDeleted(client, args.groupId)) {

--- a/backend/src/database/utils/validateCurrency.ts
+++ b/backend/src/database/utils/validateCurrency.ts
@@ -1,0 +1,8 @@
+import { BadRequestException } from '../../errors/BadRequestException'
+import { CurrencyUtils } from 'shared'
+
+export function validateCurrency(currency: string) {
+  if (!CurrencyUtils.supportedCurrencies.some((item) => item === currency)) {
+    throw new BadRequestException('api.unsupportedCurrency')
+  }
+}

--- a/frontend/app/createGroup.tsx
+++ b/frontend/app/createGroup.tsx
@@ -13,14 +13,13 @@ import { useRouter } from 'expo-router'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ScrollView, View } from 'react-native'
-
-const CURRENCIES = ['cad', 'eur', 'gbp', 'inr', 'pln', 'usd'] as const
+import { CurrencyUtils } from 'shared'
 
 function getDefaultCurrency() {
   const locale = getLocales()[0]
   const currency = locale.currencySymbol?.toLocaleLowerCase() ?? 'usd'
 
-  if (!CURRENCIES.some((item) => item === currency)) {
+  if (!CurrencyUtils.supportedCurrencies.some((item) => item === currency)) {
     return 'usd'
   }
 
@@ -36,7 +35,7 @@ function CreateGroupForm() {
   const [error, setError] = useTranslatedError()
   const { mutateAsync: createGroup, isPending } = useCreateGroup()
 
-  const currencyPickerItems = CURRENCIES.map((currency) => ({
+  const currencyPickerItems = CurrencyUtils.supportedCurrencies.map((currency) => ({
     value: currency,
     label: t(`currency.${currency}`),
   }))

--- a/frontend/app/group/[id]/addSplit/edit.tsx
+++ b/frontend/app/group/[id]/addSplit/edit.tsx
@@ -36,6 +36,7 @@ function Content({ groupInfo, split }: { groupInfo: GroupUserInfo; split: SplitW
         timestamp: timestamp,
         balances: balanceChange,
         type: split.type,
+        currency: groupInfo.currency,
       })
 
       snack.show({ message: t('split.created') })

--- a/frontend/app/group/[id]/addSplit/summary.tsx
+++ b/frontend/app/group/[id]/addSplit/summary.tsx
@@ -39,6 +39,7 @@ function Content({ groupInfo, split }: { groupInfo: GroupUserInfo; split: SplitW
         pending: false,
       })),
       type: split.type,
+      currency: groupInfo.currency,
     })
       .then(() => {
         snack.show({ message: t('split.created') })

--- a/frontend/app/group/[id]/split/[splitId]/edit.tsx
+++ b/frontend/app/group/[id]/split/[splitId]/edit.tsx
@@ -40,6 +40,7 @@ function Form({ groupInfo, splitInfo }: { groupInfo: GroupUserInfo; splitInfo: S
         total: sumToSave,
         timestamp: timestamp,
         balances: balanceChange as BalanceChange[],
+        currency: groupInfo.currency,
       })
 
       snack.show({ message: t('split.updated') })

--- a/frontend/app/group/[id]/split/[splitId]/index.tsx
+++ b/frontend/app/group/[id]/split/[splitId]/index.tsx
@@ -52,6 +52,10 @@ export default function SplitInfoScreen() {
     }
 
     try {
+      if (!groupInfo) {
+        throw new Error(`Tried to restore split version while group info hasn't loaded yet`)
+      }
+
       await updateSplit({
         groupId: Number(id),
         splitId: split.id,
@@ -64,6 +68,7 @@ export default function SplitInfoScreen() {
           change: user.change,
           pending: user.pending,
         })),
+        currency: groupInfo.currency,
       })
 
       if ((scrollableRef.current as FlatList)?.scrollToIndex) {

--- a/shared/src/CurrencyUtils.ts
+++ b/shared/src/CurrencyUtils.ts
@@ -10,6 +10,8 @@ const formatters: Record<string, (amount: string) => string> = {
 // TODO: no intl support in hermes :sadge:
 
 export class CurrencyUtils {
+  static supportedCurrencies: ['cad', 'eur', 'gbp', 'inr', 'pln', 'usd']
+
   static format(
     amount: number | string,
     currency?: string,

--- a/shared/src/endpointArguments.ts
+++ b/shared/src/endpointArguments.ts
@@ -18,6 +18,7 @@ export interface CreateSplitArguments {
   timestamp: number
   balances: BalanceChange[]
   type: number
+  currency: string
 }
 
 export interface DeleteSplitArguments {
@@ -38,6 +39,7 @@ export interface UpdateSplitArguments {
   total: number
   timestamp: number
   balances: BalanceChange[]
+  currency: string
 }
 
 export interface SetGroupAccessArguments {

--- a/shared/src/locales/en/translation.json
+++ b/shared/src/locales/en/translation.json
@@ -87,6 +87,7 @@
   "api": {
     "invalidArguments": "Invalid arguments",
     "mustBeLoggedIn": "You must be logged in to do that",
+    "unsupportedCurrency": "This currency is not supported",
     "auth": {
       "unknownProvider": "Unknown provider",
       "missingToken": "Missing token",


### PR DESCRIPTION
Sends group currency when creating and updating splits. Adds validation that the currency is supported when creating a group.